### PR TITLE
65 retour sur AMI pendant une démarche OTV

### DIFF
--- a/app/src/main/java/fr/gouv/ami/home/WebViewScreen.kt
+++ b/app/src/main/java/fr/gouv/ami/home/WebViewScreen.kt
@@ -3,6 +3,9 @@ package fr.gouv.ami.home
 import android.util.Log
 import android.webkit.JavascriptInterface
 import android.content.res.Configuration
+import android.webkit.JsPromptResult
+import android.webkit.JsResult
+import android.webkit.WebChromeClient
 import android.webkit.WebView
 import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
@@ -153,6 +156,18 @@ fun WebViewScreen(
                             settings.allowContentAccess = true
                             settings.domStorageEnabled = true
                             Log.d(TAG, "Creating MainWebViewClient with baseURL ${baseUrl}")
+                            webChromeClient = object : WebChromeClient() {
+                                // Required for Android WebView to handle beforeunload confirmation dialogs
+                                override fun onJsBeforeUnload(
+                                    view: WebView?,
+                                    url: String?,
+                                    message: String?,
+                                    result: JsResult?
+                                ): Boolean {
+                                    Log.d(TAG, "onJsBeforeUnload is called")
+                                    return super.onJsBeforeUnload(view, url, message, result)
+                                }
+                            }
                             webViewClient = MainWebViewClient(
                                 baseUrl = baseUrl,
                                 onBackBarChanged = { hasBackBar = it },

--- a/app/src/main/java/fr/gouv/ami/home/WebViewScreen.kt
+++ b/app/src/main/java/fr/gouv/ami/home/WebViewScreen.kt
@@ -1,5 +1,6 @@
 package fr.gouv.ami.home
 
+import android.app.Activity
 import android.util.Log
 import android.webkit.JavascriptInterface
 import android.content.res.Configuration
@@ -131,7 +132,7 @@ fun WebViewScreen(
 
                 if (hasBackBar) {
                     BackBar {
-                        webViewViewModel.onBackPressed()
+                        (context as Activity).onBackPressed()
                     }
                 }
 

--- a/app/src/main/java/fr/gouv/ami/home/WebViewViewModel.kt
+++ b/app/src/main/java/fr/gouv/ami/home/WebViewViewModel.kt
@@ -47,11 +47,6 @@ class WebViewViewModel : BaseViewModel() {
         isOnContactPage = url.contains("/#/contact")
     }
 
-    fun onBackPressed() {
-        Log.d(TAG, "onBackPressed")
-        onGoHome()
-    }
-
     fun onGoHome() {
         Log.d(TAG, "onGoHome to ${baseUrl}")
         currentUrl = baseUrl


### PR DESCRIPTION
Le retour sur AMI pendant une démarche OTV déclenche l'affichage d'une popup pour prévenir que les données seront supprimées. Sur Android, cette popup ne s'affichait pas donc le retour arrière (natif et custom) ne fonctionnait pas. 

L'override simple de la fonction onJsBeforeUnload permet de déclencher l'affichage de la popup.

<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/f5dba2c1-a2ee-4c01-92dc-129cddbcb8c8" />
