### PR TITLE
Rendre device id asynchrone

### DIFF
--- a/app/src/androidTest/java/fr/gouv/ami/PrivateStorageTest.kt
+++ b/app/src/androidTest/java/fr/gouv/ami/PrivateStorageTest.kt
@@ -29,7 +29,7 @@ class PrivateStorageTest {
             val context = ApplicationProvider.getApplicationContext<Context>()
 
             storage = PrivateStorage(
-                DataStoreFactory.create(context, "test")
+                DataStoreFactory.get(context, "test")
             )
         }
     }

--- a/app/src/androidTest/java/fr/gouv/ami/SecureStorageTest.kt
+++ b/app/src/androidTest/java/fr/gouv/ami/SecureStorageTest.kt
@@ -29,8 +29,8 @@ class SecureStorageTest {
             val context = ApplicationProvider.getApplicationContext<Context>()
 
             secureStorage = SecureStorage(
-                DataStoreFactory.create(context, "test_encrypted"),
-                DataStoreFactory.create(context, "test_authenticated")
+                DataStoreFactory.get(context, "test_encrypted"),
+                DataStoreFactory.get(context, "test_authenticated")
             )
         }
     }

--- a/app/src/main/java/fr/gouv/ami/MainApp.kt
+++ b/app/src/main/java/fr/gouv/ami/MainApp.kt
@@ -53,7 +53,6 @@ fun HomeApp(
     var isConnected by remember {
         mutableStateOf(false)
     }
-    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         val token = storage.bearerToken.first()
@@ -76,12 +75,6 @@ fun HomeApp(
                     }
                 }
         }
-    }
-
-    LaunchedEffect(Unit) {
-        val localStorage = ILocalStorageRepository(context)
-        //localStorage.writeString("Test", "toto chiffré", KeyStoreManager.SecurityLevelType.Encrypted)
-
     }
 
     if (pendingUrl != null) {

--- a/app/src/main/java/fr/gouv/ami/home/WebViewScreen.kt
+++ b/app/src/main/java/fr/gouv/ami/home/WebViewScreen.kt
@@ -49,6 +49,8 @@ import fr.gouv.ami.ui.theme.AMITheme
 import fr.gouv.ami.home.WebviewScripts.EventWebview
 import fr.gouv.ami.utils.storage.LowStorageManager
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @Composable
@@ -194,11 +196,14 @@ fun WebViewScreen(
                                     WebViewFeature.DOCUMENT_START_SCRIPT
                                 )
                             ) {
-                                /*WebViewCompat.addDocumentStartJavaScript(
-                                    this,
-                                    nativeInfosScript(context),
-                                    setOf("*")
-                                )*/
+                                CoroutineScope(Dispatchers.IO).launch {
+                                    WebViewCompat.addDocumentStartJavaScript(
+                                        webViewRef.value!!,
+                                        nativeInfosScript(context),
+                                        setOf("*")
+                                    )
+                                }
+
                             }
 
                             addJavascriptInterface(object {

--- a/app/src/main/java/fr/gouv/ami/home/WebViewScreen.kt
+++ b/app/src/main/java/fr/gouv/ami/home/WebViewScreen.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 fun WebViewScreen(
@@ -202,8 +203,16 @@ fun WebViewScreen(
                                         nativeInfosScript(context),
                                         setOf("*")
                                     )
-                                }
 
+                                    withContext(Dispatchers.Main) {
+                                        loadUrl(webViewViewModel.currentUrl)
+                                    }
+                                }
+                            }
+                            else {
+                                // No need to wait for Coroutine to load NativeInfos JS.
+                                // Call loadURL as before. We are on Main UI Thread.
+                                loadUrl(webViewViewModel.currentUrl)
                             }
 
                             addJavascriptInterface(object {
@@ -253,7 +262,6 @@ fun WebViewScreen(
                                     }
                                 }
                             }, "NativeBridge")
-                            loadUrl(webViewViewModel.currentUrl)
                         }
                         swipeRefreshRef.value?.addView(webViewRef.value)
 

--- a/app/src/main/java/fr/gouv/ami/home/WebViewScreen.kt
+++ b/app/src/main/java/fr/gouv/ami/home/WebViewScreen.kt
@@ -194,11 +194,11 @@ fun WebViewScreen(
                                     WebViewFeature.DOCUMENT_START_SCRIPT
                                 )
                             ) {
-                                WebViewCompat.addDocumentStartJavaScript(
+                                /*WebViewCompat.addDocumentStartJavaScript(
                                     this,
                                     nativeInfosScript(context),
                                     setOf("*")
-                                )
+                                )*/
                             }
 
                             addJavascriptInterface(object {

--- a/app/src/main/java/fr/gouv/ami/home/WebviewScripts.kt
+++ b/app/src/main/java/fr/gouv/ami/home/WebviewScripts.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.util.Log
 import fr.gouv.ami.BuildConfig
 import fr.gouv.ami.R
-import fr.gouv.ami.notifications.FirebaseService
+import fr.gouv.ami.utils.DeviceIdUtils
 
 class WebviewScripts {
 
@@ -24,11 +24,11 @@ class WebviewScripts {
     companion object {
         val TAG = this::class.java.simpleName
 
-        fun nativeInfosScript(
+        suspend fun nativeInfosScript(
             context: Context
         ): String {
-            //val deviceId = FirebaseService().getOrCreateDeviceId()
-            //Log.d(TAG, "device_id sending in nativeInfosScript is $deviceId")
+            val deviceId = DeviceIdUtils(context).getOrCreateDeviceId()
+            Log.d(TAG, "device_id sending in nativeInfosScript is $deviceId")
 
             return """
         (function() {
@@ -42,6 +42,7 @@ class WebviewScripts {
                     build: ${BuildConfig.VERSION_CODE},
                     environment: "${BuildConfig.FLAVOR}",
                     mode: "${BuildConfig.BUILD_TYPE}",
+                    device_id: "$deviceId"
                 };
             };
         })();

--- a/app/src/main/java/fr/gouv/ami/notifications/FirebaseService.kt
+++ b/app/src/main/java/fr/gouv/ami/notifications/FirebaseService.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
-import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
@@ -22,14 +21,11 @@ import fr.gouv.ami.api.apiService
 import fr.gouv.ami.api.baseUrl
 import fr.gouv.ami.data.models.Subscription
 import fr.gouv.ami.data.models.SubscriptionRequest
+import fr.gouv.ami.utils.DeviceIdUtils
 import fr.gouv.ami.utils.storage.LowStorageManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import java.util.UUID
 
 class FirebaseService : FirebaseMessagingService() {
 
@@ -70,9 +66,10 @@ class FirebaseService : FirebaseMessagingService() {
                 }
             }
             if (bearer != null) {
+                val deviceId = DeviceIdUtils(applicationContext).getOrCreateDeviceId()
                 val subscription = Subscription(
                     fcmToken = token,
-                    deviceId = getOrCreateDeviceId(),
+                    deviceId = deviceId,
                     platform = "android",
                     appVersion = BuildConfig.VERSION_NAME,
                     model = getDeviceModel()
@@ -134,16 +131,6 @@ class FirebaseService : FirebaseMessagingService() {
         val notificationManager: NotificationManager =
             getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.createNotificationChannel(channel)
-    }
-
-    suspend fun getOrCreateDeviceId(): String {
-        var deviceId = storageManager.deviceId.first()
-        if (deviceId == null) {
-            deviceId = UUID.randomUUID().toString()
-            storageManager.saveDeviceId(deviceId)
-        }
-        Log.d(TAG, "Using Android ID as device ID: $deviceId")
-        return deviceId
     }
 
     /**

--- a/app/src/main/java/fr/gouv/ami/utils/DeviceIdUtils.kt
+++ b/app/src/main/java/fr/gouv/ami/utils/DeviceIdUtils.kt
@@ -13,7 +13,7 @@ class DeviceIdUtils(val context: Context) {
     private val DEVICE_ID_KEY = stringPreferencesKey("device_id")
     private val SETTING_STORAGE_KEY = "settings"
     private val privateStorage =
-        PrivateStorage(DataStoreFactory.create(context, SETTING_STORAGE_KEY))
+        PrivateStorage(DataStoreFactory.get(context, SETTING_STORAGE_KEY))
 
     suspend fun getOrCreateDeviceId(): String {
         val deviceIdResult = privateStorage.readData(DEVICE_ID_KEY)

--- a/app/src/main/java/fr/gouv/ami/utils/DeviceIdUtils.kt
+++ b/app/src/main/java/fr/gouv/ami/utils/DeviceIdUtils.kt
@@ -1,0 +1,39 @@
+package fr.gouv.ami.utils
+
+import android.content.Context
+import android.util.Log
+import androidx.datastore.preferences.core.stringPreferencesKey
+import fr.gouv.ami.utils.storage.DataStoreFactory
+import fr.gouv.ami.utils.storage.PrivateStorage
+import java.util.UUID
+
+class DeviceIdUtils(val context: Context) {
+
+    private val TAG = this::class.java.simpleName
+    private val DEVICE_ID_KEY = stringPreferencesKey("device_id")
+    private val SETTING_STORAGE_KEY = "settings"
+    private val privateStorage =
+        PrivateStorage(DataStoreFactory.create(context, SETTING_STORAGE_KEY))
+
+    suspend fun getOrCreateDeviceId(): String {
+        val deviceIdResult = privateStorage.readData(DEVICE_ID_KEY)
+        val deviceId: String =
+            when (deviceIdResult) {
+                is Result.Success -> {
+                    deviceIdResult.value
+                }
+
+                is Result.Failure -> {
+                    createDeviceId()
+                }
+            }
+        Log.d(TAG, "the deviceId is $deviceId")
+        return deviceId
+    }
+
+    private suspend fun createDeviceId(): String {
+        val deviceId = UUID.randomUUID().toString()
+        privateStorage.writeData(DEVICE_ID_KEY, deviceId)
+        return deviceId
+    }
+}

--- a/app/src/main/java/fr/gouv/ami/utils/storage/ILocalStorageRepository.kt
+++ b/app/src/main/java/fr/gouv/ami/utils/storage/ILocalStorageRepository.kt
@@ -17,11 +17,11 @@ class ILocalStorageRepository(val context: Context) : LocalStorageRepositoryProt
     init {
         val userStoreId = "tmp" //TODO à changer
         privateStorage = PrivateStorage(
-            DataStoreFactory.create(context, userStoreId)
+            DataStoreFactory.get(context, userStoreId)
         )
         secureStorage = SecureStorage(
-            DataStoreFactory.create(context, "${userStoreId}_encrypted"),
-            DataStoreFactory.create(context, "${userStoreId}_authenticated")
+            DataStoreFactory.get(context, "${userStoreId}_encrypted"),
+            DataStoreFactory.get(context, "${userStoreId}_authenticated")
         )
     }
 

--- a/app/src/main/java/fr/gouv/ami/utils/storage/LowStorageManager.kt
+++ b/app/src/main/java/fr/gouv/ami/utils/storage/LowStorageManager.kt
@@ -17,7 +17,8 @@ class LowStorageManager(private val context: Context) {
     }
 
     private val FIREBASE_TOKEN = stringPreferencesKey("firebase_token")
-    private val DEVICE_ID = stringPreferencesKey("device_id")
+
+    //private val DEVICE_ID = stringPreferencesKey("device_id")
     private val BEARER_TOKEN = stringPreferencesKey("bearer_token")
 
     suspend fun saveFirebaseToken(token: String) {
@@ -50,15 +51,5 @@ class LowStorageManager(private val context: Context) {
         context.dataStore.edit { preferences ->
             preferences.remove(BEARER_TOKEN)
         }
-    }
-
-    suspend fun saveDeviceId(deviceId: String) {
-        context.dataStore.edit { preferences ->
-            preferences[DEVICE_ID] = deviceId
-        }
-    }
-
-    val deviceId: Flow<String?> = context.dataStore.data.map { preferences ->
-        preferences[DEVICE_ID]
     }
 }

--- a/app/src/main/java/fr/gouv/ami/utils/storage/PrivateStorage.kt
+++ b/app/src/main/java/fr/gouv/ami/utils/storage/PrivateStorage.kt
@@ -55,13 +55,20 @@ class PrivateStorage(val dataStore: DataStore<Preferences>) {
 
 object DataStoreFactory {
 
-    fun create(
+    private val stores = mutableMapOf<String, DataStore<Preferences>>()
+
+    @Synchronized
+    fun get(
         context: Context,
         userStoreId: String
-    ): DataStore<Preferences> =
-        PreferenceDataStoreFactory.create(
-            produceFile = {
-                context.preferencesDataStoreFile(userStoreId)
-            }
-        )
+    ): DataStore<Preferences> {
+
+        return stores.getOrPut(userStoreId) {
+            PreferenceDataStoreFactory.create(
+                produceFile = {
+                    context.applicationContext.preferencesDataStoreFile(userStoreId)
+                }
+            )
+        }
+    }
 }


### PR DESCRIPTION
Suite à la PR https://github.com/numerique-gouv/ami-app-android/pull/76 la sauvegarde et la lecture d'une clé dans le datastore sont asynchrone. De fait, le deviceId ne pouvait plus être donné dès le chargement de la webview.
Maintenant l'ajout du script est dans une coroutine pour qu'il puisse être injecté que quand le device Id est disponible.

Il est possible de rajouter ce bout de code dans le script window.NativeInfos.getInfos pour pouvoir voir les infos mises à disposition dans la webview :

```
window.NativeInfos.displayBanner = function() {
                const banner = document.createElement('native-info-banner');
                banner.innerText = JSON.stringify(
                    window.NativeInfos.getInfos()
                );
                banner.style.cssText = `
                    position: fixed;
                    top: 0;
                    left: 0;
                    width: 100%;
                    padding: 12px 16px;
                    background-color: #007AFF;
                    color: white;
                    font-size: 16px;
                    font-family: sans-serif;
                    font-weight: 600;
                    z-index: 999999;
                    box-sizing: border-box;
                    text-align: center;
                `;
                
                console.log("body =", document.body);
                document.body?.insertBefore(
                    banner,
                    document.body.firstChild
                );
            };
            console.log('NativeInfos initialized');
            
            if (document.body) {
                window.NativeInfos.displayBanner();
            } else {
                document.addEventListener(
                    'DOMContentLoaded',
                    window.NativeInfos.displayBanner,
                    { once: true }
                );
            }
```