### PR TITLE
autoriser la passkey dans la webview

### DIFF
--- a/app/src/main/java/fr/gouv/ami/home/WebViewScreen.kt
+++ b/app/src/main/java/fr/gouv/ami/home/WebViewScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import fr.gouv.ami.R
@@ -258,11 +259,27 @@ fun WebViewScreen(
 
                         swipeRefreshRef.value!!
                     },
-                    update = { webView ->
-                        if (webViewRef.value?.url != webViewViewModel.currentUrl) {
-                            webViewRef.value?.loadUrl(webViewViewModel.currentUrl)
-                        }
+                    update = { _ ->
                         swipeRefreshRef.value?.isRefreshing = webViewViewModel.isRefreshing
+
+                        //allow passkey if it is available
+                        run {
+                            if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_AUTHENTICATION)) {
+                                WebSettingsCompat.setWebAuthenticationSupport(
+                                    webViewRef.value?.settings!!,
+                                    WebSettingsCompat.WEB_AUTHENTICATION_SUPPORT_FOR_APP,
+                                )
+                                // Check if getWebauthenticationSupport may have been disabled by the WebView.
+                                Log.e(
+                                    TAG,
+                                    "getWebAuthenticationSupport result: " + WebSettingsCompat.getWebAuthenticationSupport(
+                                        webViewRef.value?.settings!!
+                                    ),
+                                )
+                            } else {
+                                Log.e(TAG, "WebView does not support passkeys.")
+                            }
+                        }
                     }
                 )
             }


### PR DESCRIPTION
Pour la mise en place des passkey coté back, il y a besoin d'un paramètrage dans la webview pour que la webapp puisse avoir l'autorisation de les utiliser ([PR #1113]( https://github.com/numerique-gouv/ami-notifications-api/pull/1113)) 